### PR TITLE
[18.0][IMP] sale_stock_available_to_promise_release: expected_date on sale report

### DIFF
--- a/sale_stock_available_to_promise_release/models/sale_order.py
+++ b/sale_stock_available_to_promise_release/models/sale_order.py
@@ -10,6 +10,9 @@ class SaleOrder(models.Model):
     move_need_release_count = fields.Integer(
         string="Moves Need Release", compute="_compute_move_need_release_count"
     )
+    is_ok_expected_delivery_date = fields.Boolean(
+        compute="_compute_is_ok_expected_delivery_date"
+    )
 
     @api.depends("picking_ids.move_ids.need_release")
     def _compute_move_need_release_count(self):
@@ -17,6 +20,24 @@ class SaleOrder(models.Model):
             sale.move_need_release_count = len(
                 sale.picking_ids.move_ids.filtered("need_release")
             )
+
+    @api.depends("expected_date", "order_line.availability_status")
+    def _compute_is_ok_expected_delivery_date(self):
+        for sale in self:
+            if not (sale.commitment_date or sale.expected_date):
+                sale.is_ok_expected_delivery_date = False
+                continue
+            for line in sale.order_line:
+                if (
+                    not line.display_type
+                    and not line.is_delivery
+                    and not line.product_id.type == "service"
+                    and line.availability_status in ("full", "partial", "on_order")
+                ):
+                    sale.is_ok_expected_delivery_date = True
+                    break
+            else:
+                sale.is_ok_expected_delivery_date = False
 
     def action_open_move_need_release(self):
         self.ensure_one()

--- a/sale_stock_available_to_promise_release/reports/sale_order.xml
+++ b/sale_stock_available_to_promise_release/reports/sale_order.xml
@@ -54,5 +54,25 @@
                 </t>
             </td>
         </xpath>
+
+        <xpath expr="//div[@name='expiration_date']" position="after">
+            <div
+                t-if="doc.is_ok_expected_delivery_date"
+                class="col"
+                name="expected_delivery_date"
+            >
+                <strong>Expected delivery</strong>
+                <div
+                    t-if="doc.commitment_date"
+                    t-field="doc.commitment_date"
+                    t-options="{'widget': 'date'}"
+                />
+                <div
+                    t-else=""
+                    t-field="doc.expected_date"
+                    t-options="{'widget': 'date'}"
+                />
+            </div>
+        </xpath>
     </template>
 </odoo>

--- a/sale_stock_available_to_promise_release/tests/__init__.py
+++ b/sale_stock_available_to_promise_release/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_sale_line_availability_status
+from . import test_sale_ok_expected_date

--- a/sale_stock_available_to_promise_release/tests/test_sale_ok_expected_date.py
+++ b/sale_stock_available_to_promise_release/tests/test_sale_ok_expected_date.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+from .common import Common
+
+
+class TestSaleOkExpectedDate(Common):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_2 = cls.env["product.product"].create(
+            {
+                "name": "Test Storable Product Two",
+                "uom_id": cls.uom_unit.id,
+                "type": "consu",
+                "is_storable": True,
+            }
+        )
+        # Have a line on the order that will not activate the feature
+        cls.line_2 = cls.env["sale.order.line"].create(
+            {
+                "order_id": cls.sale.id,
+                "product_id": cls.product_2.id,
+                "product_uom_qty": 100,
+                "product_uom": cls.uom_unit.id,
+            },
+        )
+
+    def test_expected_date_ok(self):
+        self.sale.action_confirm()
+        self._set_stock(self.product, 100)
+        self.assertTrue(self.sale.is_ok_expected_delivery_date)
+
+    def test_no_availability(self):
+        self.sale.action_confirm()
+        self.assertFalse(self.sale.is_ok_expected_delivery_date)
+
+    def test_no_expected_date(self):
+        self.sale.action_confirm()
+        self.sale.expected_date = False
+        self.assertFalse(self.sale.commitment_date)
+        self.assertFalse(self.sale.is_ok_expected_delivery_date)
+
+    def test_no_expected_date_for_service(self):
+        self.line.unlink()
+        self.product_2.type = "service"
+        self.sale.action_confirm()
+        self.assertFalse(self.sale.is_ok_expected_delivery_date)


### PR DESCRIPTION
This is a forward port of the module

    `sale_stock_available_to_promise_release_cutoff`

from the branch 14.0 of the wms repository.

Because the module was wrongly named and the `sale_delivery_date` module is obsolete, this is added as a feature of this module