### PR TITLE
[18.0][PERF] stock_available_to_promise_release: perf + fix allocation view

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -19,7 +19,7 @@ class StockPicking(models.Model):
         compute="_compute_release_ready", search="_search_release_ready"
     )
     release_ready_count = fields.Integer(
-        string="# of moves ready", compute="_compute_release_ready"
+        string="# of moves ready", compute="_compute_release_ready_count"
     )
     date_priority = fields.Datetime(
         string="Priority Date",
@@ -85,15 +85,26 @@ class StockPicking(models.Model):
         self.move_ids.invalidate_recordset(["ordered_available_to_promise_qty"])
         for picking in self:
             moves = picking.move_ids.filtered(lambda move: move._is_release_needed())
-            release_ready = False
-            release_ready_count = sum(1 for move in moves if move._is_release_ready())
-            if moves:
-                if picking.release_policy == "one":
-                    release_ready = release_ready_count == len(moves)
-                else:
-                    release_ready = bool(release_ready_count)
-            picking.release_ready_count = release_ready_count
-            picking.release_ready = release_ready
+            if not moves:
+                picking.release_ready = False
+            elif picking.release_policy == "one":
+                picking.release_ready = all(move._is_release_ready() for move in moves)
+            else:
+                picking.release_ready = any(move._is_release_ready() for move in moves)
+
+    # move_ids.ordered_available_to_promise_qty has no depends, so we need to
+    # invalidate cache before accessing this release_ready computed value
+    @api.depends(lambda self: self._get_release_ready_depends())
+    def _compute_release_ready_count(self):
+        self.move_ids.invalidate_recordset(["ordered_available_to_promise_qty"])
+        for picking in self:
+            moves = picking.move_ids.filtered(lambda move: move._is_release_needed())
+            if not moves:
+                picking.release_ready_count = 0
+            else:
+                picking.release_ready_count = sum(
+                    1 for move in moves if move._is_release_ready()
+                )
 
     def _search_release_ready(self, operator, value):
         if operator != "=":

--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -59,20 +59,62 @@
     <record id="view_picking_release_tree" model="ir.ui.view">
         <field name="name">stock.picking.release.tree</field>
         <field name="model">stock.picking</field>
-        <field name="mode">primary</field>
-        <field name="inherit_id" ref="stock.vpicktree" />
-        <field eval="900" name="priority" />
+        <field name="inherit_id" eval="False" />
         <field name="arch" type="xml">
-            <field name="origin" position="after">
-                <field name="group_id" optional="hide" />
-            </field>
-            <field name="scheduled_date" position="after">
-                <field name="last_release_date" optional="hide" />
-            </field>
-            <list position="inside">
-                <field name="date_priority" optional="show" />
+            <list
+                string="Picking list"
+                multi_edit="1"
+                sample="1"
+                js_class="stock_list_view"
+            >
+                <field name="name" decoration-bf="1" />
+                <field
+                    name="location_id"
+                    options="{'no_create': True}"
+                    string="From"
+                    groups="stock.group_stock_multi_locations"
+                    optional="hide"
+                    readonly="state == 'done'"
+                />
+                <field
+                    name="location_dest_id"
+                    options="{'no_create': True}"
+                    string="To"
+                    groups="stock.group_stock_multi_locations"
+                    optional="hide"
+                    readonly="state == 'done'"
+                />
+                <field
+                    name="partner_id"
+                    optional="show"
+                    readonly="state in ['cancel', 'done']"
+                />
+                <field name="priority" widget="priority" nolabel="1" />
+                <field name="date_priority" />
                 <field name="need_release" column_invisible="1" />
                 <field name="release_ready" />
+                <field
+                    name="scheduled_date"
+                    optional="hide"
+                    widget="remaining_days"
+                    invisible="state in ('done', 'cancel')"
+                    readonly="state in ['cancel', 'done']"
+                />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="hide"
+                />
+                <field
+                    name="state"
+                    optional="show"
+                    widget="badge"
+                    decoration-danger="state=='cancel'"
+                    decoration-info="state== 'assigned'"
+                    decoration-muted="state == 'draft'"
+                    decoration-success="state == 'done'"
+                    decoration-warning="state not in ('draft','cancel','done','assigned')"
+                />
                 <field name="release_ready_count" />
                 <button
                     name="action_open_move_need_release"
@@ -81,6 +123,10 @@
                     icon="fa-cubes"
                     type="object"
                     invisible="not need_release"
+                />
+                <field
+                    name="activity_exception_decoration"
+                    widget="activity_exception"
                 />
             </list>
         </field>


### PR DESCRIPTION
* Make a dedicated view for the Allocation Transfers
* split realease_ready and release_ready_count as the first is used more often and the second is more expensive to compute
* Hide by default the sale expected date

cc @simahawk @sebalix @rousseldenis @lmignon 