### PR TITLE
[18.0][IMP] stock_available_to_promise_release: show warehouse in move allocation

### DIFF
--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -7,6 +7,9 @@
         <field name="inherit_id" ref="stock.view_move_tree" />
         <field eval="900" name="priority" />
         <field name="arch" type="xml">
+            <field name="reference" position="before">
+                <field name="warehouse_id" optional="hide" />
+            </field>
             <field name="reference" position="after">
                 <field name="partner_id" string="Customer" />
                 <field name="origin" optional="show" />
@@ -43,6 +46,7 @@
         <field eval="900" name="priority" />
         <field name="arch" type="xml">
             <group name="main_grp_col2" position="inside">
+                <field name="warehouse_id" />
                 <field name="ordered_available_to_promise_uom_qty" />
                 <field name="date_priority" />
             </group>


### PR DESCRIPTION
The warehouse is used for computing available stock. Allow to view if the warehouse is set.

cc @rousseldenis @mt-software-de @lmignon 