### PR TITLE
[18.0][FIX]sale_stock_available_to_promise_release: Fix availability status

### DIFF
--- a/sale_stock_available_to_promise_release/models/sale_order_line.py
+++ b/sale_stock_available_to_promise_release/models/sale_order_line.py
@@ -56,15 +56,26 @@ class SaleOrderLine(models.Model):
             data["availability_status"] = "full"
             data["available_qty"] = self.product_uom_qty
             return data
+        product = self.product_id
         # Fallback values
         availability_status = "no"
         expected_availability_date = False
-        available_qty = sum(
-            self.mapped("move_ids.ordered_available_to_promise_uom_qty")
-        )
+        available_qty = 0
+        for move in self.move_ids:
+            if move.state == "cancel":
+                continue
+            if move.need_release:
+                available_qty += self.product_uom._compute_quantity(
+                    move.ordered_available_to_promise_uom_qty,
+                    product.uom_id,
+                    rounding_method="HALF-UP",
+                )
+            else:
+                available_qty += self.product_uom._compute_quantity(
+                    move.quantity, move.product_uom, rounding_method="HALF-UP"
+                )
         delayed_qty = 0
         # required values
-        product = self.product_id
         rounding = product.uom_id.rounding
         # Fully available
         if (

--- a/sale_stock_available_to_promise_release/tests/test_sale_ok_expected_date.py
+++ b/sale_stock_available_to_promise_release/tests/test_sale_ok_expected_date.py
@@ -28,8 +28,8 @@ class TestSaleOkExpectedDate(Common):
         )
 
     def test_expected_date_ok(self):
-        self.sale.action_confirm()
         self._set_stock(self.product, 100)
+        self.sale.action_confirm()
         self.assertTrue(self.sale.is_ok_expected_delivery_date)
 
     def test_no_availability(self):


### PR DESCRIPTION
When computing availability status, cancelled moves should be ignored.

ping @jbaudoux