### PR TITLE
[18][stock_reserve_rule][FIX] Make sure quant are really excluded from reservation if a quant_domain is set on the removal rule

### DIFF
--- a/stock_reserve_rule/models/stock_move.py
+++ b/stock_reserve_rule/models/stock_move.py
@@ -70,6 +70,7 @@ class StockMove(models.Model):
                 rule_quants = removal_rule._filter_quants(self, quants)
                 if not rule_quants:
                     continue
+                excluded_quants = quants - rule_quants
 
                 # Apply the advanced removal strategy, if any. Even within the
                 # application of the removal strategy, the original company's
@@ -84,7 +85,10 @@ class StockMove(models.Model):
                         if not next_quant:
                             continue
                         location, location_quantity, to_take = next_quant
-                        taken_in_loc = super()._update_reserved_quantity(
+                        taken_in_loc = super(
+                            StockMove,
+                            self.with_context(exclude_quant_ids=excluded_quants.ids),
+                        )._update_reserved_quantity(
                             # in this strategy, we take as much as we can
                             # from this bin
                             to_take,

--- a/stock_reserve_rule/models/stock_quant.py
+++ b/stock_reserve_rule/models/stock_quant.py
@@ -4,6 +4,7 @@
 from collections import OrderedDict
 
 from odoo import models
+from odoo.osv import expression
 
 
 class StockQuant(models.Model):
@@ -28,3 +29,26 @@ class StockQuant(models.Model):
             else:
                 seen[location] = quant
         return [(loc, quants) for loc, quants in seen.items()]
+
+    def _get_gather_domain(
+        self,
+        product_id,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        domain = super()._get_gather_domain(
+            product_id,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
+        if self.env.context.get("exclude_quant_ids"):
+            domain = expression.AND(
+                [[("id", "not in", self.env.context["exclude_quant_ids"])], domain]
+            )
+        return domain

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -241,6 +241,33 @@ class TestReserveRule(ReserveRuleCommon):
         )
         self.assertEqual(move.state, "assigned")
 
+    def test_quant_domain_same_location(self):
+        package = self.env["stock.quant.package"].create({})
+        self._update_qty_in_location(
+            self.loc_zone1_bin1, self.product1, 1, package=package
+        )
+        self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 1)
+        picking = self._create_picking(self.wh, [(self.product1, 1)])
+
+        domain = [("package_id", "=", False)]
+        self._create_rule(
+            {},
+            [
+                # This rule is not excluded by the domain,
+                # but the quant will be as the quantity is less than 200.
+                {
+                    "location_id": self.loc_zone1.id,
+                    "sequence": 1,
+                    "quant_domain": domain,
+                },
+            ],
+        )
+        picking.action_assign()
+        move = picking.move_ids
+        ml = move.move_line_ids
+        self.assertTrue(ml)
+        self.assertFalse(ml.package_id)
+
     def test_rule_empty_bin(self):
         self._update_qty_in_location(self.loc_zone1_bin1, self.product1, 300)
         self._update_qty_in_location(self.loc_zone1_bin2, self.product1, 150)


### PR DESCRIPTION
I was testing the module to solve the following use case : 
On a location, I have some products inside some packages... and some other not belonging to any package.
My goal is to reserve only product not belonging to a package for a dedicated picking type.

Let's say I have, in stock/shelf1, 1 product A in a package PACK0001 and 1 product A (without package). ProductA/PACK0001 did enters the stock first so it would be taken first with default FIFO removal strategy.

I create a reserve rule for stock location with a removal rule on stock/shelf1 with a quant_domain `[('package_id', '=', False)]` (and default advanced removal strategy)
If I create a picking with 1 stock move with product A / product_uom_qty = 1, then check the availability. The system does reserve 1 product A with the PACK0001 ! 
It actually depends on the original default strategy, but it is kind of random.

What happens is : 
The system find only the quant product A/no pack (it filters out the quant product A / PACK0001)  https://github.com/OCA/stock-logistics-reservation/blob/18.0/stock_reserve_rule/models/stock_move.py#L70
Then it will find it can reserve 1 qty in self1 because of our free eligible quant Product A/no pack : https://github.com/OCA/stock-logistics-reservation/blob/18.0/stock_reserve_rule/models/stock_move.py#L86
And then he will try to make the reservation on the location, but as it is not "strict", Odoo will search a quant, that may or not have a package, because at this time, he is now aware of the quant that are eligible https://github.com/OCA/stock-logistics-reservation/blob/18.0/stock_reserve_rule/models/stock_move.py#L95
So it takes the package quant (because it is the first one with default FIFO strategy)/

Unless I am missing something about the module/quant_domain utility, I guess this is a bug.

My fix consist in ignoring the quants that have been filtered out by our removal rule during the reservation process.

A review/opinion would be gratly appreciated @rousseldenis @jbaudoux @bizzappdev 