### PR TITLE
[18.0][FIX] stock_available_to_promise_release: fix moves merge

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -482,8 +482,10 @@ class StockMove(models.Model):
         )
 
     def _action_cancel(self):
-        # Unrelease moves that must be, before canceling them.
-        self.unrelease()
+        if not self.env.context.get("from_merge_no_need_release"):
+            # Unrelease moves that must be, before canceling them.
+            # We skip this when merging moves that are all released.
+            self.unrelease()
         super()._action_cancel()
         self.write({"need_release": False})
         return True
@@ -557,6 +559,7 @@ class StockMove(models.Model):
         unreleased_moves = released_pickings.move_ids - released_moves
         unreleased_moves_to_bo = unreleased_moves.filtered(
             lambda m: m.state not in ("done", "cancel")
+            and m.need_release
             and not m.rule_id.no_backorder_at_release
         )
         if unreleased_moves_to_bo:
@@ -583,6 +586,15 @@ class StockMove(models.Model):
 
         assigned_moves = released_moves._after_release_assign_moves()
         assigned_moves._after_release_update_chain()
+
+        # some moves may have been already released but not merged because of
+        # an ongoing quantity on the pick step. Now that both are released, try
+        # to merge them
+        prereleased_moves = unreleased_moves.filtered(
+            lambda m: m.state not in ("done", "cancel") and not m.need_release
+        )
+        if prereleased_moves:
+            prereleased_moves._merge_moves()
 
         return assigned_moves
 
@@ -929,7 +941,10 @@ class StockMove(models.Model):
 
     def write(self, vals):
         released_moves = self.browse()
-        if self.env.context.get("in_merge_mode") and "product_uom_qty" in vals:
+        if (
+            self.env.context.get("from_merge_need_release")
+            and "product_uom_qty" in vals
+        ):
             # when a move is merged, we need to unrelease it if the quantity
             # is changed and the move is unreleasable
             released_moves = self.filtered(lambda m: m._is_unreleaseable())
@@ -947,17 +962,28 @@ class StockMove(models.Model):
 
     def _is_mergeable(self):
         self.ensure_one()
-        return self.state not in ("done", "cancel") and (
-            not self._is_unreleaseable() or self.unrelease_allowed
+        return self.state not in ("draft", "done", "cancel") and (
+            self.need_release or self.unrelease_allowed
         )
 
+    def _prepare_merge_moves_distinct_fields(self):
+        fields = super()._prepare_merge_moves_distinct_fields()
+        if self.env.context.get("from_merge_no_need_release"):
+            # when we merge moves that do not need release, ensure candidates
+            # have the same value for need release (i.e. False)
+            fields.append("need_release")
+        return fields
+
     def _update_candidate_moves_list(self, candidate_moves):
-        # filter out the moves that are not unreleasable
-        res = super()._update_candidate_moves_list(candidate_moves)
         # candidate_moves is a list of recordset of moves
         # it contains one recordset per move to merge
         # each recordset contains the moves that we want to merge (an item of self)
         # and the candidate moves to merge into
+        res = super()._update_candidate_moves_list(candidate_moves)
+        if not self.env.context.get("from_merge_need_release"):
+            return res
+        # when merging a move that needs release, filter out the moves that are
+        # not unreleasable
         new_candidate_moves = [
             candidates.filtered(
                 lambda m, moves_to_merge=self: m in moves_to_merge or m._is_mergeable()
@@ -970,13 +996,36 @@ class StockMove(models.Model):
         return res
 
     def _merge_moves(self, merge_into=False):
-        # From here any write on the moves are done in the context of a merge
-        # and we need to unrelease them if the quantity is changed
-        self_ctx = self.with_context(in_merge_mode=True)
-        if merge_into:
-            merge_into = merge_into.filtered(lambda m: m._is_mergeable())
-        return (
-            super(StockMove, self_ctx)
-            ._merge_moves(merge_into=merge_into)
-            .with_context(in_merge_mode=False)
-        )
+        res = self.browse()
+        no_need_release = self.filtered(lambda m: not m.need_release)
+        if no_need_release:
+            # For moves that do not need release, search moves that also do not
+            # need release
+            from_merge_no_need_release = self.env.context.get(
+                "from_merge_no_need_release", False
+            )
+            res |= (
+                super(
+                    StockMove,
+                    no_need_release.with_context(from_merge_no_need_release=True),
+                )
+                ._merge_moves(merge_into=merge_into)
+                .with_context(from_merge_no_need_release=from_merge_no_need_release)
+            )
+        need_release = self - no_need_release
+        if need_release:
+            # For moves that do need release, search moves that also need
+            # release or are unreleasable
+            from_merge_need_release = self.env.context.get(
+                "from_merge_need_release", False
+            )
+            if merge_into:
+                merge_into = merge_into.filtered(lambda m: m._is_mergeable())
+            res |= (
+                super(
+                    StockMove, need_release.with_context(from_merge_need_release=True)
+                )
+                ._merge_moves(merge_into=merge_into)
+                .with_context(from_merge_need_release=from_merge_need_release)
+            )
+        return res

--- a/stock_available_to_promise_release/tests/test_merge_moves.py
+++ b/stock_available_to_promise_release/tests/test_merge_moves.py
@@ -1,4 +1,5 @@
 # Copyright 2024 ACSONE SA/NV
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from datetime import datetime
@@ -64,7 +65,12 @@ class TestMergeMoves(PromiseReleaseCommonCase):
             ]
         )
 
-    def test_unrelease_at_move_merge(self):
+    def test_unrelease_at_move_merge_pos(self):
+        """Test merging released and need release moves
+
+        The released move is unreleased for merging and the merged move is then
+        released for the new total quantity
+        """
         self.assertFalse(self.shipping1.need_release)
         self.assertEqual(1, len(self.shipping1.move_ids))
         original_qty = self.shipping1.move_ids.product_uom_qty
@@ -73,11 +79,21 @@ class TestMergeMoves(PromiseReleaseCommonCase):
         self.assertEqual(1, len(self.shipping1.move_ids))
         self.assertEqual(original_qty + 2, self.shipping1.move_ids.product_uom_qty)
         self.assertFalse(self.shipping1.need_release)
-        # since the shipment is no more released, the picking should be canceled
+        # the initial picking has been canceled
         self.assertEqual("cancel", self.picking1.state)
+        # the new picking is for the new total quantity
+        new_picking = self.shipping1.move_ids.move_orig_ids.filtered(
+            lambda m: m.state != "cancel"
+        )
+        self.assertEqual(original_qty + 2, new_picking.product_uom_qty)
 
-    def test_unrelease_at_move_merge_2(self):
-        # create a negative quant to cancel teh qty to deliver
+    def test_unrelease_at_move_merge_neg(self):
+        """Test merging released and need release moves
+
+        The released move is unreleased for merging and the merged move is
+        canceled as the total quantity is 0
+        """
+        # create a negative quant to cancel the qty to deliver
         self.assertFalse(self.shipping1.need_release)
         self.assertEqual(1, len(self.shipping1.move_ids))
         original_qty = self.shipping1.move_ids.product_uom_qty
@@ -88,6 +104,11 @@ class TestMergeMoves(PromiseReleaseCommonCase):
         # no more qty to deliver, the shipment and picking should be canceled
         self.assertEqual("cancel", self.shipping1.state)
         self.assertEqual("cancel", self.picking1.state)
+        # there is no new picking
+        new_picking = self.shipping1.move_ids.move_orig_ids.filtered(
+            lambda m: m.state != "cancel"
+        )
+        self.assertEqual(0, len(new_picking))
 
     def test_unrelease_at_move_merge_merged(self):
         # Create a new shipping for the same product and date
@@ -126,21 +147,28 @@ class TestMergeMoves(PromiseReleaseCommonCase):
 
         # the pick should still contain a move with the processed qty
         # and the qty to do should be the one from shipping2
-        move = self.picking1.move_ids.filtered(
+        pick_move = self.picking1.move_ids.filtered(
             lambda m: m.state in ("assigned", "partially_available")
         )
-        self.assertEqual(2, move.move_line_ids.quantity)
-        self.assertEqual(5, move.product_uom_qty)
+        self.assertEqual(2, pick_move.move_line_ids.quantity)
+        self.assertEqual(5, pick_move.product_uom_qty)
 
         # if we release the ship 1 again, a new move should be created
-        # and merged with the existing one
+        # and merged with the existing one. The 2 released ship moves will also
+        # be merged.
+        ship_moves = self.shipping1.move_ids
+        self.assertEqual(2, len(ship_moves))
         self.shipping1.release_available_to_promise()
-        move = self.picking1.move_ids.filtered(
+        # the released ship moves are still in the same shipping1
+        ship_moves = ship_moves.exists()
+        self.assertEqual(1, len(ship_moves))
+        self.assertEqual(ship_moves.picking_id, self.shipping1)
+        pick_move = self.picking1.move_ids.filtered(
             lambda m: m.state in ("assigned", "partially_available")
         )
-        self.assertEqual(1, len(move))
-        self.assertEqual(2 + original_qty_1 + original_qty_2, move.product_uom_qty)
-        self.assertEqual(2, move.move_line_ids.quantity)
+        self.assertEqual(1, len(pick_move))
+        self.assertEqual(2 + original_qty_1 + original_qty_2, pick_move.product_uom_qty)
+        self.assertEqual(2, pick_move.move_line_ids.quantity)
 
     def test_default_merge(self):
         # check that the merge is still working when the available_to_promise_defer_pull


### PR DESCRIPTION
Do not unrelease when 2 released moves are merged and do not send pre-released move to a backorder.

cc @sebalix @lmignon @rousseldenis 