### PR TITLE
[18.0][IMP] stock_available_to_promise_release: unrelease to backorder

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -561,6 +561,7 @@ class StockMove(models.Model):
             lambda m: m.state not in ("done", "cancel")
             and m.need_release
             and not m.rule_id.no_backorder_at_release
+            and m.need_release
         )
         if unreleased_moves_to_bo:
             unreleased_moves_to_bo._unreleased_to_backorder()


### PR DESCRIPTION
It is possible to unrelease a single move from a transfer. After doing so the transfer (or that single move) can be released again.

Before this change, when releasing the 2nd time, a bakorder is created for the move not being release the 2nd time (because they are already released).

After this change, all released moves stay in the same transfer only the non released move are moved in a backorder.