### PR TITLE
[18.0][IMP] stock_available_to_promise_release: menu

### DIFF
--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -137,8 +137,8 @@
     <menuitem
         action="stock_picking_release_action"
         id="stock_picking_release_menu"
-        parent="stock.menu_stock_warehouse_mgmt"
-        sequence="10"
+        parent="stock.menu_stock_transfers"
+        sequence="50"
         groups="stock.group_stock_manager,stock.group_stock_user"
     />
 </odoo>


### PR DESCRIPTION
Move "Transfers Allocations" inside "Transfers" section

| **Before** | **After** |
|--------|--------|
| <img width="286" height="876" alt="image" src="https://github.com/user-attachments/assets/ac6b503e-68d8-4aa9-aab8-7bd71a44b498" /> | <img width="286" height="876" alt="image" src="https://github.com/user-attachments/assets/eb67b1d4-5895-491d-9caf-42bc44790144" /> | 

cc @sebalix @rousseldenis 