### PR TITLE
[18.0][IMP] stock_available_to_promise_release: split order

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -565,9 +565,9 @@ class StockMove(models.Model):
         if unreleased_moves_to_bo:
             unreleased_moves_to_bo._unreleased_to_backorder()
 
+        released_moves._before_release()
         # Pull the released moves
         for move in released_moves:
-            move._before_release()
             values = move._prepare_procurement_values()
             values["move_dest_ids"] = move
             procurement_requests.append(

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -552,6 +552,8 @@ class StockMove(models.Model):
                 move._release_split(remaining_qty)
             released_moves |= move
 
+        released_moves = released_moves._before_release()
+
         # Move the unreleased moves to a backorder.
         # This behavior can be disabled by setting the flag
         # no_backorder_at_release on the stock.route of the move.
@@ -565,7 +567,6 @@ class StockMove(models.Model):
         if unreleased_moves_to_bo:
             unreleased_moves_to_bo._unreleased_to_backorder()
 
-        released_moves._before_release()
         # Pull the released moves
         for move in released_moves:
             values = move._prepare_procurement_values()
@@ -599,8 +600,12 @@ class StockMove(models.Model):
         return assigned_moves
 
     def _before_release(self):
-        """Hook that aims to be overridden."""
+        """Hook that aims to be overridden.
+
+        Return the moves that must be further released
+        """
         self._release_set_expected_date()
+        return self
 
     def _release_get_expected_date(self):
         """Return the new scheduled date of a single delivery move"""
@@ -657,17 +662,33 @@ class StockMove(models.Model):
         new_move._action_confirm(merge=False)
         return new_move
 
-    def _unreleased_to_backorder(self):
-        """Move the unreleased moves to a new backorder picking"""
+    def _unreleased_to_backorder(self, split_order=False):
+        """Move the unreleased moves to a new backorder picking
+
+        Set split_order=True when it's the released moves that are moved to a
+        split order.
+        """
         origin_pickings = {m.id: m.picking_id for m in self}
         self.with_context(release_available_to_promise=True)._assign_picking()
         backorder_links = {}
         for move in self:
             origin = origin_pickings[move.id]
             if origin:
-                backorder_links[move.picking_id] = origin
+                if not split_order:
+                    backorder_links[move.picking_id] = origin
+                else:
+                    backorder_links[origin] = move.picking_id
         for backorder, origin in backorder_links.items():
-            backorder._release_link_backorder(origin)
+            if (
+                backorder.state in ("draft", "cancel")
+                and len(backorder.backorder_ids) == 1
+            ):
+                # When the backorder order is canceled and the moves are
+                # reassigned to a new order, post a link to the real
+                # backorder. Used by the module
+                # stock_available_to_promise_release_alternative_carrier
+                backorder = backorder.backorder_ids
+            backorder._release_link_backorder(origin, split_order=split_order)
 
     def _assign_picking_post_process(self, new=False):
         res = super()._assign_picking_post_process(new)
@@ -918,11 +939,9 @@ class StockMove(models.Model):
     def _search_picking_for_assignation_domain(self):
         domain = super()._search_picking_for_assignation_domain()
         if self.env.context.get("release_available_to_promise"):
-            force_new_picking = not self.rule_id.no_backorder_at_release
-            if force_new_picking:
-                # We want a newer picking, search with '>' to prevent to select
-                # any old available picking
-                domain = expression.AND([domain, [("id", ">", self.picking_id.id)]])
+            # We want a newer picking, search with '>' to prevent to select
+            # any old available picking
+            domain = expression.AND([domain, [("id", ">", self.picking_id.id)]])
         if self.picking_type_id.prevent_new_move_after_release:
             domain = expression.AND([domain, [("last_release_date", "=", False)]])
         return domain

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -131,11 +131,24 @@ class StockPicking(models.Model):
         }
         self.move_ids.with_context(**context).release_available_to_promise()
 
-    def _release_link_backorder(self, origin_picking):
+    def _release_link_backorder(self, origin_picking, split_order=False):
         self.backorder_id = origin_picking
-        origin_picking.message_post(
-            body=self.env._("The backorder %s has been created.", self._get_html_link())
-        )
+        if origin_picking.state not in ("draft", "cancel"):
+            # in case of split order, the current picking may now be empty. In
+            # this case don't post a link, as it will be canceled and we don't
+            # want to advertise about a canceled transfer.
+            origin_picking.message_post(
+                body=self.env._(
+                    "The backorder %s has been created.", self._get_html_link()
+                )
+            )
+        if split_order:
+            self.message_post(
+                body=self.env._(
+                    "The split order %s has been created.",
+                    origin_picking._get_html_link(),
+                )
+            )
 
     def _after_release_update_chain(self):
         """Called after the moves are released


### PR DESCRIPTION
* _before_release_move on recordset
* manage "split order" to set properly the backorder links