### PR TITLE
[18.0][FIX] stock_available_to_promise_release: priority & picking type change

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -222,14 +222,7 @@ class StockMove(models.Model):
                 OR (
                     m.priority = move.priority
                     AND m.date_priority = move.date_priority
-                    AND m.picking_type_id = move.picking_type_id
                     AND m.id < move.id
-                )
-                OR (
-                    m.priority = move.priority
-                    AND m.date_priority = move.date_priority
-                    AND m.picking_type_id != move.picking_type_id
-                    AND m.id > move.id
                 )
             )
         """


### PR DESCRIPTION
When a move partially available is released, a new move is created for the remaining quantity. If the released move gets a new picking type, he cannot loose it's priority in favor of the remaining quantity move.
The change of picking type could be caused by `stock_available_to_promise_carrier_alternative`, `stock_warehouse_flow` or `stock_dynamic_routing` modules.

Revert of https://github.com/OCA/wms/pull/441
Need to find a different approach for the multi-stage release. @mt-software-de 

cc @mt-software-de @rousseldenis @lmignon @sebalix 