### PR TITLE
[18.0][FIX] stock_available_to_promise_release: kanban

### DIFF
--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -5,9 +5,6 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.stock_picking_type_kanban" />
         <field name="arch" type="xml">
-            <field name="count_picking_waiting" position="before">
-                <field name="count_picking_need_release" />
-            </field>
             <xpath
                 expr="//div[hasclass('col-6', 'stock-overview-links')]"
                 position="inside"


### PR DESCRIPTION
Fix migration to v18.0