### PR TITLE
[18.0][FIX] stock_available_to_promise_release: fix query for horizon

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -498,15 +498,6 @@ class StockMove(models.Model):
     def release_available_to_promise(self):
         return self._run_stock_rule()
 
-    def _prepare_move_split_vals(self, qty):
-        vals = super()._prepare_move_split_vals(qty)
-        # The method set procure_method as 'make_to_stock' by default on split,
-        # but we want to keep 'make_to_order' for chained moves when we split
-        # a partially available move in _run_stock_rule().
-        if self.env.context.get("release_available_to_promise"):
-            vals.update({"procure_method": self.procure_method, "need_release": True})
-        return vals
-
     def _get_release_decimal_precision(self):
         return self.env["decimal.precision"].precision_get("Product Unit of Measure")
 

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -54,7 +54,7 @@ class StockMove(models.Model):
         compute="_compute_release_ready",
         search="_search_release_ready",
     )
-    need_release = fields.Boolean(index=True, copy=False)
+    need_release = fields.Boolean(index=True)
     unrelease_allowed = fields.Boolean(compute="_compute_unrelease_allowed")
 
     @api.depends("need_release", "rule_id", "rule_id.available_to_promise_defer_pull")
@@ -256,7 +256,7 @@ class StockMove(models.Model):
         if horizon_date:
             sql += (
                 " AND (m.need_release IS true AND m.date <= %(horizon)s "
-                "      OR m.need_release IS false)"
+                f"     OR ({self._previous_promised_qty_sql_moves_no_release()}))"
             )
             params["horizon"] = horizon_date
         return sql, params

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -94,6 +94,12 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertEqual(picking4.move_ids.ordered_available_to_promise_uom_qty, 0)
         self.assertEqual(picking5.move_ids.previous_promised_qty, 48)
         self.assertEqual(picking5.move_ids.ordered_available_to_promise_uom_qty, 0)
+        # Check that splitting a move doesn't affect allocation
+        move_vals = picking.move_ids._split(1)
+        move = self.env["stock.move"].create(move_vals)
+        move._action_confirm(merge=False)
+        self.env["stock.move"].invalidate_model(fnames=["previous_promised_qty"])
+        self.assertEqual(picking2.move_ids.previous_promised_qty, 5)
 
     def test_ordered_available_to_promise_value_consider_already_released(self):
         self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
@@ -284,6 +290,15 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                 fnames=["previous_promised_qty", "ordered_available_to_promise_uom_qty"]
             )
             self.assertEqual(picking4.move_ids.previous_promised_qty, 5)
+            # split picking1 move and check that has no impact
+            move_vals = picking.move_ids._split(1)
+            move = self.env["stock.move"].create(move_vals)
+            move._action_confirm(merge=False)
+            self.env["stock.move"].invalidate_model(
+                fnames=["previous_promised_qty", "ordered_available_to_promise_uom_qty"]
+            )
+            self.assertEqual(picking4.move_ids.previous_promised_qty, 5)
+            move._action_confirm(merge=True)
 
             # set a higher priority for picking 5
             # (restoring previous date_expected values for other pickings before)
@@ -314,6 +329,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         with freeze_time("2019-09-03"):
             # last picking won't have available qty again
             self.assertEqual(picking4.move_ids.ordered_available_to_promise_uom_qty, 0)
+
 
     def test_ordered_available_to_promise_value_by_priority(self):
         self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -330,7 +330,6 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             # last picking won't have available qty again
             self.assertEqual(picking4.move_ids.ordered_available_to_promise_uom_qty, 0)
 
-
     def test_ordered_available_to_promise_value_by_priority(self):
         self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
         picking, picking2, picking3, picking4, picking5 = self._create_pickings()


### PR DESCRIPTION
In case a move is split, ensure `need_release` is not lost.

Also drop the force `procure_method` in case of split during a release. This is now standard odoo since v15.0

cc @mmequignon @mt-software-de 