### PR TITLE
[18.0][IMP] Allow to force reassignation of partially assigned moves

### DIFF
--- a/stock_reserve_rule/models/stock_move.py
+++ b/stock_reserve_rule/models/stock_move.py
@@ -127,3 +127,23 @@ class StockMove(models.Model):
             owner_id=owner_id,
             strict=strict,
         )
+
+    def _action_assign(self, force_qty=False):
+        unreserve_locations = {}
+        partially_assigned_moves = self.filtered(
+            lambda mov: mov.state == "partially_available"
+        )
+
+        for move in partially_assigned_moves:
+            to_unreserve = unreserve_locations.setdefault(
+                move.location_id.id,
+                any(
+                    rule.force_reassign_partial
+                    for rule in self.env["stock.reserve.rule"]._rules_for_location(
+                        move.location_id
+                    )
+                ),
+            )
+            if to_unreserve:
+                move.move_line_ids.unlink()
+        return super()._action_assign(force_qty=force_qty)

--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -62,6 +62,11 @@ class StockReserveRule(models.Model):
         "rule is applicable or not.",
     )
 
+    force_reassign_partial = fields.Boolean(
+        help="Check this box if you want to remove existing reservation when checking "
+        "availabilty of partially available moves."
+    )
+
     def _rules_for_location(self, location):
         return self.search([("location_id", "parent_of", location.id)])
 

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -625,3 +625,46 @@ class TestReserveRule(ReserveRuleCommon):
             ],
         )
         picking.action_assign()
+
+    def test_move_reassign_partial(self):
+        self._create_rule(
+            {"force_reassign_partial": True},
+            [{"removal_strategy": "default", "location_id": self.wh.lot_stock_id.id}],
+        )
+        self.product1.tracking = "lot"
+        lot_1 = self.env["stock.lot"].create(
+            {
+                "name": "LOT-0001",
+                "product_id": self.product1.id,
+            }
+        )
+        lot_2 = self.env["stock.lot"].create(
+            {
+                "name": "LOT-0002",
+                "product_id": self.product1.id,
+            }
+        )
+        self.env["stock.quant"]._update_available_quantity(
+            self.product1, self.wh.lot_stock_id, 10, lot_id=lot_1
+        )
+        self.env["stock.quant"]._update_available_quantity(
+            self.product1, self.wh.lot_stock_id, 5, lot_id=lot_2
+        )
+        picking_1 = self._create_picking(self.wh, [(self.product1, 10)])
+        picking_2 = self._create_picking(self.wh, [(self.product1, 10)])
+        picking_1.action_assign()
+        self.assertEqual(picking_1.move_ids.state, "assigned")
+        self.assertEqual(picking_1.move_line_ids.lot_id, lot_1)
+
+        picking_2.action_assign()
+        self.assertEqual(picking_2.move_ids.state, "partially_available")
+        self.assertEqual(picking_2.move_line_ids.lot_id, lot_2)
+
+        picking_1.action_cancel()
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product1, self.wh.lot_stock_id, 10, lot_id=lot_2
+        )
+
+        picking_2.action_assign()
+        self.assertEqual(picking_2.move_line_ids.lot_id, lot_1)

--- a/stock_reserve_rule/views/stock_reserve_rule_views.xml
+++ b/stock_reserve_rule/views/stock_reserve_rule_views.xml
@@ -26,6 +26,7 @@
                                 widget="many2many_tags"
                                 options="{'no_create': 1}"
                             />
+                            <field name="force_reassign_partial" />
                             <field name="sequence" />
                         </group>
                         <group>


### PR DESCRIPTION
In case a move is partially assigned, it might have reserved a lot or pack that would not be the one reserved when the remaining quantity is assigned.

Let us consider we have 10 units of both LOT1 and LOT2 in stock and LOT1 has to be taken first by removal strategy. When a MOVE1 with a qty of 10 is assigned, it can reserve full quantity of LOT1. When a MOVE2 with a qty of 15 is assigned it will reserve the 10 units from LOT2.
Now, if MOVE1 gets canceled, if will free the 10 units of LOT1. As MOVE2 is not fully assigned, only the remaining unassigned quantity still has to be reserved and if action_assign is triggered on MOVE2, it will reserve 5 units of LOT1. In that case MOVE2 will be fully assigned with 10 units of LOT2 and 5 units of LOT1 while 5 units of LOT1 remain unassigned in the stock.

With this new option, the existing reservation on LOT2 would be removed, what would allow to reserve 10 units of LOT1 and 5 units of LOT2.