### PR TITLE
[18.0][FIX] stock_available_to_promise_release: split

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -538,6 +538,8 @@ class StockMove(models.Model):
 
         released_moves = released_moves._before_release()
 
+        released_moves.need_release = False
+
         # Move the unreleased moves to a backorder.
         # This behavior can be disabled by setting the flag
         # no_backorder_at_release on the stock.route of the move.

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -48,15 +48,6 @@ class StockRule(models.Model):
                 actions_to_run.append((procurement, rule))
 
         super()._run_pull(actions_to_run)
-        # use first a list of ids and browse it afterwards for performance
-        move_ids = [
-            move.id
-            for proc, _rule in actions_to_run
-            for move in proc.values.get("move_dest_ids", [])
-        ]
-        if move_ids:
-            moves = self.env["stock.move"].browse(move_ids)
-            moves.filtered(lambda r: r.need_release).write({"need_release": False})
         return True
 
 


### PR DESCRIPTION
Ensure released moves are not marked anymore as need_release before defer is called.

In case defer splits the move, we need to ensure the move is not marked as need release.

Fixes https://github.com/OCA/stock-logistics-reservation/pull/49/changes/7b6453e78f8a0eaa8a0d620bb5348a99a65c2d47#diff-fca2e9865c2d75a9793dbe699bffdf976606d996b69d09cacd25660f2926e998L57

cc @mmequignon @TDu  @mt-software-de