### PR TITLE
[18.0][FIX] stock_reserve_rule: Pick bigger package over FIFO

### DIFF
--- a/stock_reserve_rule/models/stock_reserve_rule.py
+++ b/stock_reserve_rule/models/stock_reserve_rule.py
@@ -284,14 +284,14 @@ class StockReserveRuleRemoval(models.Model):
         def is_greater_eq(value, other):
             return float_compare(value, other, precision_rounding=rounding) >= 0
 
-        for location, location_quants in quants_per_bin:
-            location_quantity = sum(location_quants.mapped("quantity")) - sum(
-                location_quants.mapped("reserved_quantity")
-            )
-            if location_quantity <= 0:
-                continue
+        for pack_quantity in packaging_quantities:
+            for location, location_quants in quants_per_bin:
+                location_quantity = sum(location_quants.mapped("quantity")) - sum(
+                    location_quants.mapped("reserved_quantity")
+                )
+                if location_quantity <= 0:
+                    continue
 
-            for pack_quantity in packaging_quantities:
                 enough_for_packaging = is_greater_eq(location_quantity, pack_quantity)
                 asked_at_least_packaging_qty = is_greater_eq(need, pack_quantity)
                 if enough_for_packaging and asked_at_least_packaging_qty:

--- a/stock_reserve_rule/tests/common.py
+++ b/stock_reserve_rule/tests/common.py
@@ -100,9 +100,11 @@ class ReserveRuleCommon(BaseCommon):
             )
         return picking
 
-    def _update_qty_in_location(self, location, product, quantity, in_date=None):
+    def _update_qty_in_location(
+        self, location, product, quantity, in_date=None, package=None
+    ):
         self.env["stock.quant"]._update_available_quantity(
-            product, location, quantity, in_date=in_date
+            product, location, quantity, package_id=package, in_date=in_date
         )
 
     def _create_rule(self, rule_values, removal_values):

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -480,6 +480,53 @@ class TestReserveRule(ReserveRuleCommon):
             [{"location_id": self.loc_zone1_bin2.id, "quantity": 50.0}],
         )
 
+    def test_rule_packaging_fifo_pack(self):
+        self._setup_packagings(
+            self.product1,
+            [("Pallet", 500, self.pallet), ("Retail Box", 100, self.retail_box)],
+        )
+        pack_1, pack_2 = self.env["stock.quant.package"].create(
+            [{"name": "PACK0001"}, {"name": "PACK0002"}]
+        )
+        self._update_qty_in_location(
+            self.loc_zone1_bin1,
+            self.product1,
+            100,
+            in_date=fields.Datetime.to_datetime("2021-01-02 12:00:00"),
+            package=pack_1,
+        )
+        self._update_qty_in_location(
+            self.loc_zone1_bin2,
+            self.product1,
+            500,
+            in_date=fields.Datetime.to_datetime("2021-01-04 12:00:00"),
+            package=pack_2,
+        )
+        self._create_rule(
+            {},
+            [
+                {
+                    "location_id": self.loc_zone1.id,
+                    "sequence": 1,
+                    "removal_strategy": "packaging",
+                },
+            ],
+        )
+
+        picking = self._create_picking(self.wh, [(self.product1, 500)])
+        # Pick from biggest packaging
+        picking.action_assign()
+        self.assertRecordValues(
+            picking.move_ids.move_line_ids,
+            [
+                {
+                    "location_id": self.loc_zone1_bin2.id,
+                    "quantity": 500.0,
+                    "package_id": pack_2.id,
+                }
+            ],
+        )
+
     def test_rule_packaging_0_packaging(self):
         # a packaging mistakenly created with a 0 qty should be ignored,
         # not make the reservation fail


### PR DESCRIPTION
In case a stock reserve rule is defined to use 'Full packaging', the rule must favour picking the pack matching the requested quantity instead of priorizing the removal strategy.

In case we have a product with packagings of 100 and 500, and a pack of 500 that is more recent than a pack of 100, the reservation has to favour the pack of 500 over the FIFO strategy.