### PR TITLE
[FIX] stock_reserve_rule: prevent reassignment when picked

### DIFF
--- a/stock_reserve_rule/__manifest__.py
+++ b/stock_reserve_rule/__manifest__.py
@@ -4,7 +4,8 @@
     "name": "Stock Reservation Rules",
     "summary": "Configure reservation rules by location",
     "version": "18.0.1.2.1",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
+    "maintainers": ["jbaudoux"],
     "website": "https://github.com/OCA/stock-logistics-reservation",
     "category": "Stock Management",
     "depends": [

--- a/stock_reserve_rule/models/stock_move.py
+++ b/stock_reserve_rule/models/stock_move.py
@@ -1,5 +1,5 @@
 # Copyright 2019 Camptocamp SA
-# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2019 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import models
 from odoo.tools.float_utils import float_compare
@@ -131,7 +131,7 @@ class StockMove(models.Model):
     def _action_assign(self, force_qty=False):
         unreserve_locations = {}
         partially_assigned_moves = self.filtered(
-            lambda mov: mov.state == "partially_available"
+            lambda m: not m.picked and m.state == "partially_available"
         )
 
         for move in partially_assigned_moves:

--- a/stock_reserve_rule/tests/test_reserve_rule.py
+++ b/stock_reserve_rule/tests/test_reserve_rule.py
@@ -713,5 +713,12 @@ class TestReserveRule(ReserveRuleCommon):
             self.product1, self.wh.lot_stock_id, 10, lot_id=lot_2
         )
 
+        # When picked, reassign won't occur
+        picking_2.move_line_ids.picked = True
+        picking_2.action_assign()
+        self.assertEqual(picking_2.move_line_ids.lot_id, lot_2)
+
+        # Should switch to lot1 according to FIFO
+        picking_2.move_line_ids.picked = False
         picking_2.action_assign()
         self.assertEqual(picking_2.move_line_ids.lot_id, lot_1)


### PR DESCRIPTION
Fix of 
* https://github.com/OCA/stock-logistics-reservation/pull/52

@grindtildeath 